### PR TITLE
Use public CircleCI context for build secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,28 +100,33 @@ workflows:
   build:
     jobs:
       - setup:
+          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
       - watch:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:
             tags:
               only: /.*/
       - test:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:
             tags:
               only: /.*/
       - build:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - test
           filters:
             tags:
               only: /.*/
       - publish:
+          context: Honeycomb Secrets for Public Repos
           requires:
             - build
           filters:


### PR DESCRIPTION
* currently secrets are pulled from the project env variables in CircleCI
* using a shared context consolidates secrets storage, makes for easier secret updates
* secret values are unchanged from what's currently in the project env variables
* (secrets are still internal to Honeycombers)

Each job uses the [buildevents orb](https://github.com/honeycombio/buildevents-orb/), which requires the buildevents env variables. Adding the context in each job is equivalent to what happens today with project env variables. 

### Considerations

* Removing buildevents -- it sounds that in the past having buildevents caused forked PRs not to build. This is not ideal, but I think this is an issues with buildevents/buildevents orb. It should allow the build to run, even if there's no secrets.