### PR TITLE
Add installation instructions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
 # honeyvent
 CLI for sending individual events in to [Honeycomb](https://honeycomb.io/docs)
 
-Use - call with a collection of names and values to send an event from the
+## Installation
+
+If you have a working go environment in your build, the easiest way to install `honeyvent` is via `go get`.
+
+```
+go get github.com/honeycombio/honeyvent/
+```
+
+## Usage
+
+Call with a collection of names and values to send an event from the
 command line:
 
 ```


### PR DESCRIPTION
Most other honey commands have details of how to install (like https://github.com/honeycombio/buildevents/blob/main/README.md#installation).

I noticed this repo was missing that detail, so I've added it in order to help future travelers who might not know this is a go tool.