### PR TITLE
Fix dependabot PR builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,6 @@ workflows:
   build:
     jobs:
       - setup:
-          context: Honeycomb Secrets for Public Repos
           filters:
             tags:
               only: /.*/
@@ -111,15 +110,17 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              ignore:
+                - /pull\/.*/
+                - /dependabot\/.*/
       - test:
-          context: Honeycomb Secrets for Public Repos
           requires:
             - setup
           filters:
             tags:
               only: /.*/
       - build:
-          context: Honeycomb Secrets for Public Repos
           requires:
             - test
           filters:


### PR DESCRIPTION
Failed build: https://app.circleci.com/pipelines/github/honeycombio/honeyvent/22/workflows/cbc68877-1b27-4542-9346-5d2918e59efa (build is Unauthorized because every job is using a secret context not available to external folks)

* remove secret context from jobs that don't need them
* omit forked and dependabot PRs from buildevents watch job