### PR TITLE
add our custom action to manage project labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    labels:
+      - "type: maintenance"
     reviewers:
       - "honeycombio/integrations-team"

--- a/.github/workflows/apply-labels.yml
+++ b/.github/workflows/apply-labels.yml
@@ -1,0 +1,16 @@
+name: Apply project labels
+
+on:
+  - issues
+  - label
+  - pull_request_target
+  - pull_request
+
+jobs:
+  apply-labels:
+    runs-on: ubuntu-latest
+    name: Apply common project labels
+    steps:
+      - uses: honeycombio/integrations-labels@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also tell dependabot to label PRs as maintenance.