### PR TITLE
Fix -t flag for setting timestamp

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,9 +54,9 @@ func main() {
 	}
 
 	c := libhoney.Config{
-		APIKey: opts.WriteKey,
-		Dataset:  opts.Dataset,
-		APIHost:  u.String(),
+		APIKey:  opts.WriteKey,
+		Dataset: opts.Dataset,
+		APIHost: u.String(),
 	}
 	libhoney.Init(c)
 	defer libhoney.Close()
@@ -67,8 +67,9 @@ func main() {
 	if opts.Timestamp != "" {
 		t1, err := time.Parse(time.RFC3339, opts.Timestamp)
 		if err != nil {
-			ev.Timestamp = t1
+			errAndExit(fmt.Sprintf("Unable to parse timestamp: %v", err))
 		}
+		ev.Timestamp = t1
 	}
 	for i, name := range opts.Name {
 		if val, err := strconv.Atoi(opts.Val[i]); err == nil {


### PR DESCRIPTION
The flag never had any effect because the error-checking condition was inverted. It set the timestamp only when `err != nil`, so the timestamp was always a zero value.

This also changes honeyvent to exit with a non-zero status code when time-parsing fails rather than silently continuing with the current time. This could be considered a breaking change. If it's a problem, I'm happy to just fix the error check.