### PR TITLE
Non-zero exit if honeycomb API returns an error

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,9 @@ func main() {
 		})
 	}
 
+	if rsp.Err != nil {
+		errAndExit(rsp.Err.Error())
+	}
 }
 
 func errAndExit(reason string) {


### PR DESCRIPTION
Before:
```
$ ./honeyvent -k foo -d ismith-test -n a -v b
$ echo $?
0
```

After:
```
$ ./honeyvent -k foo -d ismith-test -n a -v b
Error: got unexpected HTTP status 401: Unauthorized
$ echo $?
1
```

Fixes #9.