### PR TITLE
Don't parse nan and inf as floats

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,6 +80,10 @@ func main() {
 	for i, name := range opts.Name {
 		if val, err := strconv.Atoi(opts.Val[i]); err == nil {
 			ev.AddField(name, val)
+		} else if val := strings.ToLower(opts.Val[i]); val == "nan" || val == "inf" || val == "-inf" {
+			// special exception because we don't want these special floats to parse as float
+			// since then the field will get dropped on ingestion
+			ev.AddField(name, val)
 		} else if val, err := strconv.ParseFloat(opts.Val[i], 64); err == nil {
 			ev.AddField(name, val)
 		} else {


### PR DESCRIPTION
This specially handles values corresponding to the special items that Go's float parser turns into special float values: NaN, inf, and -inf. If these values get to shepherd, the corresponding fields are dropped.

This handles those cases as strings instead of floats, and fixes #7. 

The image shows a mixture of raw data for before (the blank ones) and after the fix.

![image](https://user-images.githubusercontent.com/755528/126840163-d279a719-75e3-4f9c-9edc-e2ebadb66381.png)
