### PR TITLE
--no-tls-verify

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type Options struct {
 	Name        []string `short:"n" long:"name" description:"Metric name"`
 	Val         []string `short:"v" long:"value" description:"Metric value"`
 	Verbose     bool     `short:"V" long:"verbose" description:"Show output"`
-	NoTLSVerify bool     `long:"no-tls-verify" description:"Allow a cert that can't be verified"`
+	NoTLSVerify bool     `long:"no-tls-verify" description:"Skip TLS certificate verification"`
 }
 
 // parseAPIHost parses the provided APIHost argument and sets sensible defaults if they are not provided.

--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"strconv"
@@ -17,12 +19,13 @@ var BuildID string
 type Options struct {
 	APIHost string `hidden:"true" long:"api_host" description:"APIHost for the Honeycomb API" default:"https://api.honeycomb.io/"`
 
-	WriteKey  string   `short:"k" long:"writekey" description:"Team write key" required:"true"`
-	Dataset   string   `short:"d" long:"dataset" description:"Name of the dataset" required:"true"`
-	Timestamp string   `short:"t" long:"timestamp" description:"Set a specific timestamp (RFC3339) for this event (override the default of now)"`
-	Name      []string `short:"n" long:"name" description:"Metric name"`
-	Val       []string `short:"v" long:"value" description:"Metric value"`
-	Verbose   bool     `short:"V" long:"verbose" description:"Show output"`
+	WriteKey    string   `short:"k" long:"writekey" description:"Team write key" required:"true"`
+	Dataset     string   `short:"d" long:"dataset" description:"Name of the dataset" required:"true"`
+	Timestamp   string   `short:"t" long:"timestamp" description:"Set a specific timestamp (RFC3339) for this event (override the default of now)"`
+	Name        []string `short:"n" long:"name" description:"Metric name"`
+	Val         []string `short:"v" long:"value" description:"Metric value"`
+	Verbose     bool     `short:"V" long:"verbose" description:"Show output"`
+	NoTLSVerify bool     `long:"no-tls-verify" description:"Allow a cert that can't be verified"`
 }
 
 // parseAPIHost parses the provided APIHost argument and sets sensible defaults if they are not provided.
@@ -57,6 +60,10 @@ func main() {
 	u, err := parseAPIHost(opts.APIHost)
 	if err != nil {
 		errAndExit(fmt.Sprintf("Unable to parse API host: %s", err.Error()))
+	}
+
+	if opts.NoTLSVerify {
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
 	c := libhoney.Config{


### PR DESCRIPTION
You should never use it in prod, but sometimes for testing purposes,
it's nice to be able to hit a server and allow that yes, the cert is
self-signed or has the wrong name.

I've been doing this with `curl -k`, but ... let's make it an option
here.

Tested locally with:
```
± go run . --no-tls-verify -k $DOGFOOD_LIBHONEY_WRITE_KEY -d ismith-test -n name -v honeyvent --api_host=https://refinery-eks.ext.dogfood.honeycomb.io
± go run . -k $DOGFOOD_LIBHONEY_WRITE_KEY -d ismith-test -n name -v honeyvent --api_host=https://refinery-eks.ext.dogfood.honeycomb.io
Error: Post "https://refinery-eks.ext.dogfood.honeycomb.io/1/batch/ismith-test": x509: certificate is valid for *.honeycomb.io, *.hny.co, honeycomb.io, hny.co, *.hound.sh, hound.sh, not refinery-eks.ext.dogfood.honeycomb.io
exit status 1
```