### PR TITLE
Bump libhoney-go to v1.15.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/honeycombio/libhoney-go v1.15.5
+	github.com/honeycombio/libhoney-go v1.15.6
 	github.com/jessevdk/go-flags v1.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/facebookgo/stack v0.0.0-20160209184415-751773369052 h1:JWuenKqqX8nojt
 github.com/facebookgo/stack v0.0.0-20160209184415-751773369052/go.mod h1:UbMTZqLaRiH3MsBH8va0n7s1pQYcu3uTb8G4tygF4Zg=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4 h1:7HZCaLC5+BZpmbhCOZJ293Lz68O7PYrF2EzeiFMwCLk=
 github.com/facebookgo/subset v0.0.0-20200203212716-c811ad88dec4/go.mod h1:5tD+neXqOorC30/tWg0LCSkrqj/AR6gu8yY8/fpw1q0=
-github.com/honeycombio/libhoney-go v1.15.5 h1:Djren7ovq6pnPljEow3F1uu3FCc9ailigm9qtTPpEWA=
-github.com/honeycombio/libhoney-go v1.15.5/go.mod h1:8NyBoM746bz+nw3yQzQF8gtJO/z4mkr/MD5C4r4uC2Y=
+github.com/honeycombio/libhoney-go v1.15.6 h1:zbwfdo74Gsedmu6OT/oAHv4pfKNoseTXRMA/4e5XWew=
+github.com/honeycombio/libhoney-go v1.15.6/go.mod h1:8NyBoM746bz+nw3yQzQF8gtJO/z4mkr/MD5C4r4uC2Y=
 github.com/jessevdk/go-flags v1.5.0 h1:1jKYvbxEjfUl0fmqTCOfonvskHHXMjBySTLW4y9LFvc=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/klauspost/compress v1.13.5 h1:9O69jUPDcsT9fEm74W92rZL9FQY7rCdaXVneq+yyzl4=

--- a/vendor/github.com/honeycombio/libhoney-go/CHANGELOG.md
+++ b/vendor/github.com/honeycombio/libhoney-go/CHANGELOG.md
@@ -1,5 +1,19 @@
 # libhoney Changelog
 
+## 1.15.6 2021-11-03
+
+### Fixed
+
+- Ensure valid JSON even when individual events in a batch can't be marshalled (#151)
+
+### Maintenance
+
+- empower apply-labels action to apply labels (#150)
+- add min go version to readme (#147)
+- update certs in old CI image (#148)
+- ci: remove buildevents from nightly (#144)
+- ci: secrets management (#142)
+
 ## 1.15.5 2021-09-27
 
 ### Fixed

--- a/vendor/github.com/honeycombio/libhoney-go/README.md
+++ b/vendor/github.com/honeycombio/libhoney-go/README.md
@@ -10,6 +10,10 @@ Go library for sending events to [Honeycomb](https://honeycomb.io), a service fo
 
 For tracing support and automatic instrumentation of Gorilla, `httprouter`, `sqlx`, and other common libraries, check out our [Beeline for Go](https://github.com/honeycombio/beeline-go).
 
+## Dependencies
+
+Golang 1.12+
+
 ## Contributions
 
 Features, bug fixes and other changes to libhoney are gladly accepted. Please

--- a/vendor/github.com/honeycombio/libhoney-go/libhoney.go
+++ b/vendor/github.com/honeycombio/libhoney-go/libhoney.go
@@ -33,7 +33,7 @@ const (
 	defaultSampleRate = 1
 	defaultAPIHost    = "https://api.honeycomb.io/"
 	defaultDataset    = "libhoney-go dataset"
-	version           = "1.15.5"
+	version           = "1.15.6"
 
 	// DefaultMaxBatchSize how many events to collect in a batch
 	DefaultMaxBatchSize = 50

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -6,7 +6,7 @@ github.com/facebookgo/clock
 github.com/facebookgo/limitgroup
 # github.com/facebookgo/muster v0.0.0-20150708232844-fd3d7953fd52
 github.com/facebookgo/muster
-# github.com/honeycombio/libhoney-go v1.15.5
+# github.com/honeycombio/libhoney-go v1.15.6
 ## explicit
 github.com/honeycombio/libhoney-go
 github.com/honeycombio/libhoney-go/transmission


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Bumps libhoney-go to latest v1.15.6.

## Short description of the changes
- updates libhoney-go to v1.15.6 in go.mod/sum

