### PR TITLE
maint: update circle image to go1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
   linuxgo:
     working_directory: /home/circleci/go/src/github.com/honeycombio/honeyvent
     docker:
-      - image: cimg/go:1.17
+      - image: cimg/go:1.18
         environment:
           GO111MODULE: "on"
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- closes #50 

## Short description of the changes

- update circle image to cimg/go:1.18 (which is currently up to 1.18.1)

