### PR TITLE
maint: update release doc and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/honeyvent?color=success)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
 
-CLI for sending individual events in to [Honeycomb](https://honeycomb.io/docs)
+CLI for sending individual events in to [Honeycomb](https://docs.honeycomb.io)
 
 ## Installation
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 1. Use [go-licenses](https://github.com/google/go-licenses) to ensure all project dependency licenses are correctly represented in this repository:
     - Install go-licenses (if not already installed) `go install github.com/google/go-licenses@latest`
-    - Run and save licenses `go-licenses save github.com/honeyvent --save_path="./LICENSES"`
+    - Run and save licenses `go-licenses save github.com/honeycombio/honeyvent --save_path="./LICENSES"`
     - If there are any changes, submit PR to update licenses.
 1. Update `CHANGELOG.md` with the changes since the last release.
 1. Commit changes, push, and open a release preparation PR for review.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,14 @@
 # Release Process
 
-1. Use [go-licenses](https://github.com/google/go-licenses) to ensure all project dependency licenses are correclty represented in this repository:
-  1. Install go-licenses (if not already installed) `go install github.com/google/go-licenses@latest`
-  2. Run and save licenses `go-licenses save github.com/honeycombio/buildevents --save_path="./LICENSES"`
-  3. If there are any changes, submit PR to update licenses.
-2. Add release entry to [changelog](./CHANGELOG.md)
-3. Open a PR with the above, and merge that into main
-4. Create new tag on merged commit with the new version (e.g. `v1.4.1`)
-5. Push the tag upstream (this will kick off the release pipeline in CI)
-6. Copy change log entry for newest version into draft GitHub release created as part of CI publish steps
+1. Use [go-licenses](https://github.com/google/go-licenses) to ensure all project dependency licenses are correctly represented in this repository:
+    - Install go-licenses (if not already installed) `go install github.com/google/go-licenses@latest`
+    - Run and save licenses `go-licenses save github.com/honeyvent --save_path="./LICENSES"`
+    - If there are any changes, submit PR to update licenses.
+1. Update `CHANGELOG.md` with the changes since the last release.
+1. Commit changes, push, and open a release preparation PR for review.
+1. Once the pull request is merged, fetch the updated main branch.
+1. Apply a tag for the new version on the merged commit (e.g. `git tag -a v1.4.1 -m "v1.4.1"`)
+1. Push the tag upstream to kick off the release pipeline in CI (e.g. `git push origin v1.4.1`).
+1. Ensure that there is a draft GitHub release created as part of CI publish steps
+1. Edit the draft GitHub release: click the Generate Release Notes button and double-check the content against the CHANGELOG.
+1. Publish the GitHub release


### PR DESCRIPTION
## Which problem is this PR solving?

- incorrect link go-licenses command in release doc

## Short description of the changes

- fix link in go-licenses command
- update releasing doc for extra details like we have in other repos
- update docs link in readme
