### PR TITLE
docs: Update Installation steps to include instructions for go install with go 1.17+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ If you have a working go environment in your build, the easiest way to install `
 go get github.com/honeycombio/honeyvent/
 ```
 
+If you're using go 1.17 or greater you should use `go install` instead, since `go get` is [deprecated](https://go.dev/doc/go-get-install-deprecation).
+
+```
+go install github.com/honeycombio/honeyvent@latest
+```
+
 ## Usage
 
 Call with a collection of names and values to send an event from the


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please make sure to:
- Chat with us first if this is a big change
  - Open a new issue (or comment on an existing one)
  - We want to make sure you don't spend time implementing something we might have to say No to
- Add unit tests
- Mention any relevant issues in the PR description (e.g. "Fixes #123")

Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Update installation steps on the Readme file.

## Short description of the changes

Since Go 1.17 that `go get` is deprecated and `go install` should be used instead: https://go.dev/doc/go-get-install-deprecation

